### PR TITLE
fixed nasty bug in BasePeerBehaviour (OnPeerAttachedAsync)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,3 +9,6 @@ Target application: **DLT**.
 -- Work In Progres --
 
 ![](https://github.com/MithrilMan/MithrilShards/workflows/Master/badge.svg)
+
+Discord server: https://discord.gg/T9kyKz4bAu
+Join to give feedback, ask for features, support, etc...

--- a/src/MithrilShards.Chain.Bitcoin/Protocol/Processors/BaseProcessor.cs
+++ b/src/MithrilShards.Chain.Bitcoin/Protocol/Processors/BaseProcessor.cs
@@ -65,10 +65,7 @@ namespace MithrilShards.Chain.Bitcoin.Protocol.Processors
       {
          if (this.isHandshakeAware)
          {
-            this.RegisterLifeTimeSubscription(this.eventBus.Subscribe<PeerHandshaked>(async (receivedEvent) =>
-            {
-               await this.OnPeerHandshakedAsync().ConfigureAwait(false);
-            }));
+            this.RegisterLifeTimeEventHandler<PeerHandshaked>(async (receivedEvent) => await this.OnPeerHandshakedAsync().ConfigureAwait(false), IsCurrentPeer);
          }
 
          return default;
@@ -80,17 +77,6 @@ namespace MithrilShards.Chain.Bitcoin.Protocol.Processors
       protected virtual ValueTask OnPeerHandshakedAsync()
       {
          return default;
-      }
-
-
-      /// <summary>
-      /// Registers the component life time subscription to an <see cref="IEventBus"/> event that will be automatically
-      /// unregistered once the component gets disposed.
-      /// </summary>
-      /// <param name="subscription">The subscription.</param>
-      protected void RegisterLifeTimeSubscription(SubscriptionToken subscription)
-      {
-         this.eventSubscriptionManager.RegisterSubscriptions(subscription);
       }
 
       /// <summary>
@@ -245,6 +231,16 @@ namespace MithrilShards.Chain.Bitcoin.Protocol.Processors
       protected bool IsSupported(int minVersion)
       {
          return this.PeerContext.NegotiatedProtocolVersion.Version >= minVersion;
+      }
+
+      /// <summary>
+      /// Helper methods that returns if a specified received peer events (an event that inherit from <see cref="PeerEventBase"/>) belongs to current peer.
+      /// Used usually as the clause for <see cref="RegisterLifeTimeEventHandler"/> to catch only peer events relative to current peer.
+      /// </summary>
+      /// <param name="theEvent">The event.</param>
+      protected bool IsCurrentPeer(PeerEventBase theEvent)
+      {
+         return theEvent.PeerContext == this.PeerContext;
       }
 
       public virtual void Dispose()

--- a/src/MithrilShards.Core/Threading/PeriodicWork.cs
+++ b/src/MithrilShards.Core/Threading/PeriodicWork.cs
@@ -50,6 +50,7 @@ namespace MithrilShards.Core.Threading
          this.eventBus = eventBus;
 
          this.Id = Guid.NewGuid();
+         logger.LogDebug("Created periodic work {IPeriodicWorkId}", this.Id);
       }
 
       public void Configure(bool stopOnException = false, IPeriodicWorkExceptionHandler? exceptionHandler = null)

--- a/src/MithrilShards.Example.Node/log-settings2.json
+++ b/src/MithrilShards.Example.Node/log-settings2.json
@@ -1,6 +1,6 @@
 ﻿{
    "Serilog": {
-      "Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.Seq" ],
+      "Using": [ "Serilog.Sinks.Console"],
       "Enrich": [ "FromLogContext", "WithMachineName", "WithThreadId" ],
       "WriteTo": [
          {
@@ -10,10 +10,6 @@
                "outputTemplate": "{Timestamp:yyyy-MM-dd HH:mm:ss}|{Level} => RequestPath:{RequestPath} => {SourceContext}{NewLine}    {Message}{NewLine}{Exception}",
                "theme": "Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme::Code, Serilog.Sinks.Console"
             }
-         },
-         {
-            "Name": "Seq",
-            "Args": { "serverUrl": "http://localhost:5341" }
          }
       ],
       "MinimumLevel": {

--- a/src/MithrilShards.Example/Protocol/Processors/BaseProcessor.cs
+++ b/src/MithrilShards.Example/Protocol/Processors/BaseProcessor.cs
@@ -66,10 +66,7 @@ namespace MithrilShards.Example.Protocol.Processors
       {
          if (this.isHandshakeAware)
          {
-            this.RegisterLifeTimeSubscription(this.eventBus.Subscribe<PeerHandshaked>(async (receivedEvent) =>
-            {
-               await this.OnPeerHandshakedAsync().ConfigureAwait(false);
-            }));
+            this.RegisterLifeTimeEventHandler<PeerHandshaked>(async (receivedEvent) => await this.OnPeerHandshakedAsync().ConfigureAwait(false), IsCurrentPeer);
          }
 
          return default;
@@ -81,17 +78,6 @@ namespace MithrilShards.Example.Protocol.Processors
       protected virtual ValueTask OnPeerHandshakedAsync()
       {
          return default;
-      }
-
-
-      /// <summary>
-      /// Registers the component life time subscription to an <see cref="IEventBus"/> event that will be automatically
-      /// unregistered once the component gets disposed.
-      /// </summary>
-      /// <param name="subscription">The subscription.</param>
-      protected void RegisterLifeTimeSubscription(SubscriptionToken subscription)
-      {
-         this.eventSubscriptionManager.RegisterSubscriptions(subscription);
       }
 
       /// <summary>
@@ -239,6 +225,16 @@ namespace MithrilShards.Example.Protocol.Processors
       protected bool IsSupported(int minVersion)
       {
          return this.PeerContext.NegotiatedProtocolVersion.Version >= minVersion;
+      }
+
+      /// <summary>
+      /// Helper methods that returns if a specified received peer events (an event that inherit from <see cref="PeerEventBase"/>) belongs to current peer.
+      /// Used usually as the clause for <see cref="RegisterLifeTimeEventHandler"/> to catch only peer events relative to current peer.
+      /// </summary>
+      /// <param name="theEvent">The event.</param>
+      protected bool IsCurrentPeer(PeerEventBase theEvent)
+      {
+         return theEvent.PeerContext == this.PeerContext;
       }
 
       public virtual void Dispose()

--- a/src/MithrilShards.Network.Bedrock/BedrockForgeConnectivity.cs
+++ b/src/MithrilShards.Network.Bedrock/BedrockForgeConnectivity.cs
@@ -161,7 +161,7 @@ namespace MithrilShards.Network.Bedrock
          this.logger.LogDebug("Connection attempt to {RemoteEndPoint}", remoteEndPoint);
          try
          {
-            await using ConnectionContext connection = await this.client.ConnectAsync((IPEndPoint)remoteEndPoint).ConfigureAwait(false);
+            await using ConnectionContext connection = await this.client.ConnectAsync(remoteEndPoint).ConfigureAwait(false);
             this.logger.LogDebug("Connected to {RemoteEndPoint}", connection.RemoteEndPoint);
             await this.clientConnectionHandler.OnConnectedAsync(connection).ConfigureAwait(false);
          }

--- a/src/MithrilShards.Network.Bedrock/MithrilForgeClientConnectionHandler.cs
+++ b/src/MithrilShards.Network.Bedrock/MithrilForgeClientConnectionHandler.cs
@@ -37,6 +37,9 @@ namespace MithrilShards.Network.Bedrock
 
       public override async Task OnConnectedAsync(ConnectionContext connection)
       {
+         // TODO: we could register processors as Scoped per connection and create a scope here
+         //using var serviceProviderScope = serviceProvider.CreateScope();
+
          if (connection is null)
          {
             throw new ArgumentNullException(nameof(connection));
@@ -59,6 +62,7 @@ namespace MithrilShards.Network.Bedrock
          protocol.SetPeerContext(peerContext);
 
          this.eventBus.Publish(new PeerConnected(peerContext));
+
 
          await this.networkMessageProcessorFactory.StartProcessorsAsync(peerContext).ConfigureAwait(false);
 


### PR DESCRIPTION
fixed a nasty bug where OnPeerAttachedAsync was called on each connected peer when a new connection established
this was due to the missing check about correct PeerContext in the handler of the message