### PR TITLE
don't process disabled processors

### DIFF
--- a/src/MithrilShards.Chain.Bitcoin/Protocol/Processors/AddressProcessor.cs
+++ b/src/MithrilShards.Chain.Bitcoin/Protocol/Processors/AddressProcessor.cs
@@ -16,7 +16,7 @@ namespace MithrilShards.Chain.Bitcoin.Protocol.Processors
    {
 
       public AddressProcessor(ILogger<AddressProcessor> logger, IEventBus eventBus, IPeerBehaviorManager peerBehaviorManager)
-         : base(logger, eventBus, peerBehaviorManager, isHandshakeAware: true)
+         : base(logger, eventBus, peerBehaviorManager, isHandshakeAware: true, receiveMessagesOnlyIfHandshaked: true)
       {
       }
 

--- a/src/MithrilShards.Chain.Bitcoin/Protocol/Processors/BaseProcessor.cs
+++ b/src/MithrilShards.Chain.Bitcoin/Protocol/Processors/BaseProcessor.cs
@@ -22,31 +22,35 @@ namespace MithrilShards.Chain.Bitcoin.Protocol.Processors
       protected readonly IEventBus eventBus;
       private readonly IPeerBehaviorManager peerBehaviorManager;
       private readonly bool isHandshakeAware;
-      private INetworkMessageWriter messageWriter;
+      private readonly bool receiveMessagesOnlyIfHandshaked;
+      private bool isHandshaked = false;
+      private INetworkMessageWriter messageWriter = null!; //hack to not rising null warnings, these are initialized when calling AttachAsync
 
       /// <summary>
       /// Holds registration of subscribed <see cref="IEventBus"/> event handlers.
       /// </summary>
       private readonly EventSubscriptionManager eventSubscriptionManager = new EventSubscriptionManager();
 
-      public BitcoinPeerContext PeerContext { get; private set; }
+      public BitcoinPeerContext PeerContext { get; private set; } = null!; //hack to not rising null warnings, these are initialized when calling AttachAsync
 
       public virtual bool Enabled { get; private set; } = true;
+
+      /// <inheritdoc/>
+      public virtual bool CanReceiveMessages => isHandshaked || this.receiveMessagesOnlyIfHandshaked == false;
 
       /// <summary>Initializes a new instance of the <see cref="BaseProcessor"/> class.</summary>
       /// <param name="logger">The logger.</param>
       /// <param name="eventBus">The event bus.</param>
       /// <param name="peerBehaviorManager">The peer behavior manager.</param>
       /// <param name="isHandshakeAware">If set to <c>true</c> register the instance to be handshake aware: when the peer is handshaked, OnPeerHandshaked method will be invoked.</param>
-      public BaseProcessor(ILogger<BaseProcessor> logger, IEventBus eventBus, IPeerBehaviorManager peerBehaviorManager, bool isHandshakeAware)
+      /// <param name="receiveMessagesOnlyIfHandshaked">if set to <c>true</c> receives messages only if handshaked.</param>
+      public BaseProcessor(ILogger<BaseProcessor> logger, IEventBus eventBus, IPeerBehaviorManager peerBehaviorManager, bool isHandshakeAware, bool receiveMessagesOnlyIfHandshaked)
       {
          this.logger = logger;
          this.eventBus = eventBus;
          this.peerBehaviorManager = peerBehaviorManager;
          this.isHandshakeAware = isHandshakeAware;
-
-         this.PeerContext = null!; //hack to not rising null warnings, these are initialized when calling AttachAsync
-         this.messageWriter = null!; //hack to not rising null warnings, these are initialized when calling AttachAsync
+         this.receiveMessagesOnlyIfHandshaked = receiveMessagesOnlyIfHandshaked;
       }
 
       public async ValueTask AttachAsync(IPeerContext peerContext)
@@ -63,10 +67,16 @@ namespace MithrilShards.Chain.Bitcoin.Protocol.Processors
       /// <returns></returns>
       protected virtual ValueTask OnPeerAttachedAsync()
       {
-         if (this.isHandshakeAware)
+         this.RegisterLifeTimeEventHandler<PeerHandshaked>(async (receivedEvent) =>
          {
-            this.RegisterLifeTimeEventHandler<PeerHandshaked>(async (receivedEvent) => await this.OnPeerHandshakedAsync().ConfigureAwait(false), IsCurrentPeer);
-         }
+            this.isHandshaked = true;
+
+            if (this.isHandshakeAware)
+            {
+               await this.OnPeerHandshakedAsync().ConfigureAwait(false);
+            }
+         }, IsCurrentPeer);
+
 
          return default;
       }

--- a/src/MithrilShards.Chain.Bitcoin/Protocol/Processors/BlockHeaderProcessor.cs
+++ b/src/MithrilShards.Chain.Bitcoin/Protocol/Processors/BlockHeaderProcessor.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -27,7 +26,7 @@ namespace MithrilShards.Chain.Bitcoin.Protocol.Processors
    /// <summary>
    /// Manage the exchange of block and headers between peers.
    /// </summary>
-   /// <seealso cref="MithrilShards.Chain.Bitcoin.Protocol.Processors.BaseProcessor" />
+   /// <seealso cref="BaseProcessor" />
    public partial class BlockHeaderProcessor : BaseProcessor, IPeriodicWorkExceptionHandler,
       INetworkMessageHandler<GetHeadersMessage>,
       INetworkMessageHandler<SendHeadersMessage>,
@@ -66,7 +65,7 @@ namespace MithrilShards.Chain.Bitcoin.Protocol.Processors
                                   IPeriodicWork headerSyncLoop,
                                   IPeriodicWork blockRequestLoop,
                                   IOptions<BitcoinSettings> options)
-         : base(logger, eventBus, peerBehaviorManager, isHandshakeAware: true)
+         : base(logger, eventBus, peerBehaviorManager, isHandshakeAware: true, receiveMessagesOnlyIfHandshaked: true)
       {
          this.dateTimeProvider = dateTimeProvider;
          this.consensusParameters = consensusParameters;

--- a/src/MithrilShards.Chain.Bitcoin/Protocol/Processors/DateTimeAdjusterProcessor.cs
+++ b/src/MithrilShards.Chain.Bitcoin/Protocol/Processors/DateTimeAdjusterProcessor.cs
@@ -19,7 +19,7 @@ namespace MithrilShards.Chain.Bitcoin.Protocol.Processors
                                   IPeerBehaviorManager peerBehaviorManager,
                                   IDateTimeProvider dateTimeProvider
                                  )
-         : base(logger, eventBus, peerBehaviorManager, isHandshakeAware: true)
+         : base(logger, eventBus, peerBehaviorManager, isHandshakeAware: true, receiveMessagesOnlyIfHandshaked: true)
       {
          this.dateTimeProvider = dateTimeProvider;
       }

--- a/src/MithrilShards.Chain.Bitcoin/Protocol/Processors/HandshakeProcessor.cs
+++ b/src/MithrilShards.Chain.Bitcoin/Protocol/Processors/HandshakeProcessor.cs
@@ -39,7 +39,12 @@ namespace MithrilShards.Chain.Bitcoin.Protocol.Processors
                                 IUserAgentBuilder userAgentBuilder,
                                 ILocalServiceProvider localServiceProvider,
                                 IHeadersTree headersTree,
-                                SelfConnectionTracker selfConnectionTracker) : base(logger, eventBus, peerBehaviorManager, isHandshakeAware: true)
+                                SelfConnectionTracker selfConnectionTracker) : base(logger,
+                                                                                    eventBus,
+                                                                                    peerBehaviorManager,
+                                                                                    isHandshakeAware: true,
+                                                                                    // we are performing handshake so we want to receive messages before handshake status
+                                                                                    receiveMessagesOnlyIfHandshaked: false)
       {
          this.dateTimeProvider = dateTimeProvider;
          this.randomNumberGenerator = randomNumberGenerator;

--- a/src/MithrilShards.Chain.Bitcoin/Protocol/Processors/PingPongProcessor.cs
+++ b/src/MithrilShards.Chain.Bitcoin/Protocol/Processors/PingPongProcessor.cs
@@ -38,7 +38,7 @@ namespace MithrilShards.Chain.Bitcoin.Protocol.Processors
                                IRandomNumberGenerator randomNumberGenerator,
                                IDateTimeProvider dateTimeProvider,
                                IPeriodicWork periodicPing)
-         : base(logger, eventBus, peerBehaviorManager, isHandshakeAware: true)
+         : base(logger, eventBus, peerBehaviorManager, isHandshakeAware: true, receiveMessagesOnlyIfHandshaked: true)
       {
          this.randomNumberGenerator = randomNumberGenerator;
          this.dateTimeProvider = dateTimeProvider;

--- a/src/MithrilShards.Core/Network/Protocol/Processors/INetworkMessageProcessor.cs
+++ b/src/MithrilShards.Core/Network/Protocol/Processors/INetworkMessageProcessor.cs
@@ -4,12 +4,34 @@ using System.Threading.Tasks;
 namespace MithrilShards.Core.Network.Protocol.Processors
 {
    /// <summary>
-   /// Interfaces that define a generic network message
+   /// Interfaces that define a processor that can handle messages received by a connected peer.
    /// </summary>
    public interface INetworkMessageProcessor : IDisposable
    {
+      /// <summary>
+      /// Gets a value indicating whether this <see cref="INetworkMessageProcessor"/> is enabled.
+      /// Disabled processors aren't registered and so can't handle any message the remote peer is sending to us.
+      /// </summary>
+      /// <value>
+      ///   <c>true</c> if enabled; otherwise, <c>false</c>.
+      /// </value>
       bool Enabled { get; }
 
+      /// <summary>
+      /// Gets a value indicating whether this instance can receive messages.
+      /// A processor may temporary disable the message handling.
+      /// An example is when a processor has only to process messages when it's in a specific state (e.g. handshaked), so it can
+      /// set this property to false, end enable it only after the peer passes to the handshaked state.
+      /// </summary>
+      /// <value>
+      ///   <c>true</c> if this instance can receive messages; otherwise, <c>false</c>.
+      /// </value>
+      bool CanReceiveMessages { get; }
+
+      /// <summary>
+      /// Called when a new connection to a peer has been established and registered <see cref="INetworkMessageProcessor"/> are being attached to its <see cref="IPeerContext"/>.
+      /// </summary>
+      /// <param name="peerContext">The peer context this processor has been attached to.</param>
       ValueTask AttachAsync(IPeerContext peerContext);
    }
 }

--- a/src/MithrilShards.Core/Network/Protocol/Processors/PeerNetworkMessageProcessorContainer.cs
+++ b/src/MithrilShards.Core/Network/Protocol/Processors/PeerNetworkMessageProcessorContainer.cs
@@ -84,8 +84,12 @@ namespace MithrilShards.Core.Network.Protocol.Processors
 
          for (int i = 0; i < handlers.Count; i++)
          {
-            // when an handler return false, mean it doesn't want other handlers to continue parsing the message
-            if (!await handlers[i].InvokeAsync(message, cancellation).ConfigureAwait(false)) break;
+            ProcessorHandler handler = handlers[i];
+            if (handler.processor.Enabled)
+            {
+               // when an handler return false, mean it doesn't want other handlers to continue parsing the message
+               if (!await handler.InvokeAsync(message, cancellation).ConfigureAwait(false)) break;
+            }
          }
 
          return true;

--- a/src/MithrilShards.Core/Network/Protocol/Processors/PeerNetworkMessageProcessorContainer.cs
+++ b/src/MithrilShards.Core/Network/Protocol/Processors/PeerNetworkMessageProcessorContainer.cs
@@ -85,10 +85,10 @@ namespace MithrilShards.Core.Network.Protocol.Processors
          for (int i = 0; i < handlers.Count; i++)
          {
             ProcessorHandler handler = handlers[i];
-            if (handler.processor.Enabled)
+            if (handler.processor.CanReceiveMessages)
             {
                // when an handler return false, mean it doesn't want other handlers to continue parsing the message
-               if (!await handler.InvokeAsync(message, cancellation).ConfigureAwait(false)) break;
+               if (await handler.InvokeAsync(message, cancellation).ConfigureAwait(false)) break;
             }
          }
 

--- a/src/MithrilShards.Example/Protocol/Processors/HandshakeProcessor.cs
+++ b/src/MithrilShards.Example/Protocol/Processors/HandshakeProcessor.cs
@@ -31,7 +31,12 @@ namespace MithrilShards.Example.Protocol.Processors
                                 NodeImplementation nodeImplementation,
                                 IPeerBehaviorManager peerBehaviorManager,
                                 IUserAgentBuilder userAgentBuilder
-                                ) : base(logger, eventBus, peerBehaviorManager, isHandshakeAware: true)
+                                ) : base(logger,
+                                         eventBus,
+                                         peerBehaviorManager,
+                                         isHandshakeAware: true,
+                                         // we are performing handshake so we want to receive messages before handshake status
+                                         receiveMessagesOnlyIfHandshaked: false)
       {
          this.dateTimeProvider = dateTimeProvider;
          this.randomNumberGenerator = randomNumberGenerator;

--- a/src/MithrilShards.Example/Protocol/Processors/PingPongProcessor.cs
+++ b/src/MithrilShards.Example/Protocol/Processors/PingPongProcessor.cs
@@ -41,7 +41,7 @@ namespace MithrilShards.Example.Protocol.Processors
                                IDateTimeProvider dateTimeProvider,
                                IPeriodicWork periodicPing,
                                IQuoteService quoteService)
-         : base(logger, eventBus, peerBehaviorManager, isHandshakeAware: true)
+         : base(logger, eventBus, peerBehaviorManager, isHandshakeAware: true, receiveMessagesOnlyIfHandshaked: true)
       {
          this.randomNumberGenerator = randomNumberGenerator;
          this.dateTimeProvider = dateTimeProvider;


### PR DESCRIPTION
~not process disabled processors.~
~when a processor has its Enabled property to false, won't receive any messages received from the peer.~

~This flag can be used to set the processor to disabled once the peer is attached to the processor, and re-enable it when the peer handshake, to prevent any message to be handled when the peer is not handshaked yet~