### PR TITLE
fix connection handler that wasn't handling scoped services properly

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
    <PropertyGroup>
       <Copyright>2024 Mithril Man.</Copyright>
 
-		<VersionPrefix>0.3.0</VersionPrefix>
+		<VersionPrefix>0.4.0</VersionPrefix>
 		
       <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
       <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/docs/docs-placeholder.csproj
+++ b/docs/docs-placeholder.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
    <PropertyGroup>
-      <TargetFramework>net5.0</TargetFramework>
+      <TargetFramework>net8.0</TargetFramework>
       <IsPackable>false</IsPackable>
       <GenerateDocumentationFile>false</GenerateDocumentationFile>
    </PropertyGroup>

--- a/docs/example-projects/mithril-shards-example.md
+++ b/docs/example-projects/mithril-shards-example.md
@@ -87,7 +87,7 @@ public class ExampleClientPeerBinding
 
 ExampleClientPeerBinding class has an EndPoint property that represents the endpoint (IP:Address) of a remote node we'd like to connect to and it's decorated with attributes that are used to validate the configuration during the initialization of the forge.
 
-Validation of the settings make use of [System.ComponentModel.DataAnnotations](https://docs.microsoft.com/en-us/dotnet/api/system.componentmodel.dataannotations?view=net-5.0){:target="_blank"} and [RequiredAttribute](https://docs.microsoft.com/en-us/dotnet/api/system.componentmodel.dataannotations.requiredattribute?view=net-5.0){:target="_blank"} used in the example is one of those attribute that belongs to standard set.  
+Validation of the settings make use of [System.ComponentModel.DataAnnotations](https://learn.microsoft.com/en-us/dotnet/api/system.componentmodel.dataannotations?view=net-8.0){:target="_blank"} and [RequiredAttribute](https://docs.microsoft.com/en-us/dotnet/api/system.componentmodel.dataannotations.requiredattribute?view=net-8.0){:target="_blank"} used in the example is one of those attribute that belongs to standard set.  
 A different story is [IPEndPointValidator]:
 
 ```c#

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ description: Mithril Shards home page
 
 ## Goal
 
-Mithril Shards goal is to implement a .NET 6 extensible P2P network & distributed services library from scratch with focus on architecture and performance.
+Mithril Shards goal is to implement a .NET 8 extensible P2P network & distributed services library from scratch with focus on architecture and performance.
 
 Allows you to define custom network serialization protocol, easily handle payload messages and interact with the software leveraging any available features (named Shards) like Web API endpoints, cross platform Blazor UI,  and a lot of other exciting stuffs that community can implement and release to the public too!
 
@@ -18,7 +18,7 @@ The project is very ambitious and it's currently developed just by me as a pet p
 
 A random list of available tech used within Mithril Shards.
 
-- [.Net 6](https://dotnet.microsoft.com/download/dotnet/6.0){:target="_blank"} - ... for everything.
+- [.Net 8](https://dotnet.microsoft.com/download/dotnet/8.0){:target="_blank"} - ... for everything.
 - [Bedrock Framework](https://github.com/davidfowl/BedrockFramework/){:target="_blank"} - TCP/IP default connectivity implementation.
 - [Swashbuckle](https://github.com/domaindrivendev/Swashbuckle.AspNetCore){:target="_blank"} - to handle Web API in a configurable, multi-area environment and have a playground to test APIs with swagger.
 - [Serilog](https://github.com/serilog/serilog-aspnetcore){:target="_blank"} - default logging implementation.

--- a/docs/mithril-shards/forge-builder.md
+++ b/docs/mithril-shards/forge-builder.md
@@ -7,7 +7,7 @@ description: Mithril Shards implementation, ForgeBuilder class
 
 ForgeBuilder class represents the entry point of a Mithril Shards application, it allows to add a shard by calling the generic `AddShard` method, with different overloads that accept an optional strongly typed shard setting file with an optional setting file validator.
 
-By using `ConfigureLogging` it's possible to configure logging, it's basically a wrapper on  the inner [HostBuilder ConfigureLogging](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.hosting.webhostbuilder.configurelogging?view=aspnetcore-1.1&viewFallbackFrom=aspnetcore-5.0){:target="_blank"} method, you could use it to have a finer control over logging configuration and available providers, but the easier way to log is by using the available [SerilogShard] that uses Serilog to configure the logging and relies on a configurable setting file where you can specify which sink to use.
+By using `ConfigureLogging` it's possible to configure logging, it's basically a wrapper on  the inner [HostBuilder ConfigureLogging](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.hosting.webhostbuilder.configurelogging?view=aspnetcore-1.1&viewFallbackFrom=aspnetcore-8.0){:target="_blank"} method, you could use it to have a finer control over logging configuration and available providers, but the easier way to log is by using the available [SerilogShard] that uses Serilog to configure the logging and relies on a configurable setting file where you can specify which sink to use.
 You can find more details on its specific documentation page and an example of its usage in the [example project]
 
 After declaring an instance we have to specify which implementation of Forge we want to use.

--- a/docs/mithril-shards/index.md
+++ b/docs/mithril-shards/index.md
@@ -12,7 +12,7 @@ Pretending to be into a Tolkien universe, I thought of defining features as *sha
 
 To find analogies with .net naming conventions:
 
-- **Forge** (to be more precise, **ForgeBuilder**) is a [HostBuilder](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.hosting.hostbuilder?view=dotnet-plat-ext-5.0){:target="_blank"} on steroids (actually it encapsulate a HostBuilder instance).
+- **Forge** (to be more precise, **ForgeBuilder**) is a [HostBuilder](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.hosting.hostbuilder?view=net-8.0){:target="_blank"} on steroids (actually it encapsulate a HostBuilder instance).
 - **Shard** is an application part that gets merged into the hostbuilder, using dependency injection, extending its functionality 
 - **Artifact** is just an allegoric view of the result of `forgeBuilderInstance.RunConsoleAsync()`.
 

--- a/docs/shards/bitcoin/index.md
+++ b/docs/shards/bitcoin/index.md
@@ -30,7 +30,7 @@ Also if you have question or want to discuss about technical details, you can us
 ## Project Overview
 
 **Bitcoin Mithril Shard** has been built on top of **Mithril Shards** framework.
-Mithril Shards goal is to be a framework and toolkit to build *<u>modular and distributed/P2P applications using .Net 6</u>* stack, focusing both on good design, good practices and performance.
+Mithril Shards goal is to be a framework and toolkit to build *<u>modular and distributed/P2P applications using .Net 8</u>* stack, focusing both on good design, good practices and performance.
 
 Core functionalities can be glued togheter to compose the needed application, ranging from a P2P network layer, Web Api layer, Diagnostic tools, cross platform UI based on blazor, distributed eventing using SignalR, MQ brokers like RabbitMq or any kind of other useful libraries.
 

--- a/docs/shards/bitcoin/network.md
+++ b/docs/shards/bitcoin/network.md
@@ -23,7 +23,7 @@ Before being able to handshake, whenever a connection has been established betwe
 
 ## Peer Context
 
-Default Mithril Shards implementation uses `PeerContext` class to store, among other things, information like peer unique identification, direction (inbound/outbound) remote and local endpoints, user agent identification, negotiated protocol version and other attachable properties leveraging the .Net [IFeatureCollection](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.http.features.ifeaturecollection?view=aspnetcore-5.0){:target="_blank"} interface.
+Default Mithril Shards implementation uses `PeerContext` class to store, among other things, information like peer unique identification, direction (inbound/outbound) remote and local endpoints, user agent identification, negotiated protocol version and other attachable properties leveraging the .Net [IFeatureCollection](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.http.features.ifeaturecollection?view=aspnetcore-8.0){:target="_blank"} interface.
 
 Bitcoin needs some additional information and some of the properties that are ubiquitous needed among all optional Bitcoin features (shards) like wallet, APIs, indexer, etc... have been defined directly into `BitcoinPeerContext` that extends the default `PeerContext`. Some of the additional properties are Permissions (that may change the FN behavior based on its set) and TimeOffset, that's an important aspect for the consensus logic.
 

--- a/docs/shards/web-api/creating-a-controller.md
+++ b/docs/shards/web-api/creating-a-controller.md
@@ -36,7 +36,7 @@ public class ExampleController : MithrilControllerBase
 
 ### Define the area
 
-Line 1 describes, using [AreaAttribute](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.areaattribute?view=aspnetcore-5.0){:target="_blank"}, the area we want this controller to be included.
+Line 1 describes, using [AreaAttribute](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.areaattribute?view=aspnetcore-8.0){:target="_blank"}, the area we want this controller to be included.
 
 WebApiArea is an helper class that just contains a bounch of constant string of known areas: "api" and "dev".
 
@@ -92,7 +92,7 @@ Lines 13-18 declare and implement an action.
 In this case, the action is declared as `HttpGet`, this mean that it will only respond to GET requests. If you try to access that action with others HTTP verbs, it will return a status error `405 Method Not Allowed`
 
 `[ProducesResponseType(StatusCodes.Status200OK)]` declare known action status that can be returned by the action.
-It's just an helpful attribute useful to produce a better documentation on swagger interface and document definition but the action itself may even generate different statuses. This documentation however don't cover canonical Web API implementation, so [refer to .Net documentation](https://docs.microsoft.com/it-it/aspnet/core/web-api/advanced/conventions?view=aspnetcore-5.0){:target="_blank"}. to read more about it.
+It's just an helpful attribute useful to produce a better documentation on swagger interface and document definition but the action itself may even generate different statuses. This documentation however don't cover canonical Web API implementation, so [refer to .Net documentation](https://learn.microsoft.com/en-us/aspnet/core/web-api/advanced/conventions?view=aspnetcore-8.0){:target="_blank"}. to read more about it.
 
 To return an action result, the method `Ok` is invoked, passing the payload (that will be serialized in JSON) as a response.
 
@@ -132,12 +132,12 @@ public IActionResult Connect(PeerManagementConnectRequest request)
 In this example, this action will return 404 (not found) if the member variables _requiredConnection isn't set, or 400 (bad request) if the input peer isn't formatted properly as a valid endpoint. If everything goes fine it will instead return 200 (ok).
 
 !!! tip
-	In case of action problems, instead of calling BadRequest or Problem method extensions, use `ValidationProblem`, it uses a ValidationProblemDetails response that's consistent with automatic validation error responses, [as stated here](https://docs.microsoft.com/en-us/aspnet/core/web-api/?view=aspnetcore-5.0#default-badrequest-response){:target="_blank"}.
+	In case of action problems, instead of calling BadRequest or Problem method extensions, use `ValidationProblem`, it uses a ValidationProblemDetails response that's consistent with automatic validation error responses, [as stated here](https://docs.microsoft.com/en-us/aspnet/core/web-api/?view=aspnetcore-8.0#default-badrequest-response){:target="_blank"}.
 	In the example above, NotFound could be replaced with ValidationProblem too for a consistent behavior.
 
 ### Producing documentation for Swagger UI
 
-In order to produce proper documentation to be shown on Swagger UI, [XML comments within C#](https://docs.microsoft.com/it-it/aspnet/core/tutorials/getting-started-with-swashbuckle?view=aspnetcore-5.0&tabs=visual-studio#xml-comments){:target="_blank"} source can be used but the build process has to generate a documentation file.
+In order to produce proper documentation to be shown on Swagger UI, [XML comments within C#](https://docs.microsoft.com/it-it/aspnet/core/tutorials/getting-started-with-swashbuckle?view=aspnetcore-8.0&tabs=visual-studio#xml-comments){:target="_blank"} source can be used but the build process has to generate a documentation file.
 
 The easier way is to edit your project file adding this snippet:
 

--- a/docs/shards/web-api/index.md
+++ b/docs/shards/web-api/index.md
@@ -6,7 +6,7 @@ description: Mithril Shards, WebApiShard Overview
 
 WebApiShard is an important shard that allows to expose Web API endpoints based on [OpeAPI specifications](https://swagger.io/specification/){:target="_blank"}.
 
-[Swashbuckle](https://github.com/domaindrivendev/Swashbuckle.AspNetCore){:target="_blank"} is used under the hood and you can find more technical information about OpenAPI, REST APIs and Swagger concepts on [microsoft documentation](https://docs.microsoft.com/it-it/aspnet/core/tutorials/web-api-help-pages-using-swagger?view=aspnetcore-5.0){:target="_blank"}.
+[Swashbuckle](https://github.com/domaindrivendev/Swashbuckle.AspNetCore){:target="_blank"} is used under the hood and you can find more technical information about OpenAPI, REST APIs and Swagger concepts on [microsoft documentation](https://learn.microsoft.com/en-us/aspnet/core/tutorials/web-api-help-pages-using-swagger?view=aspnetcore-8.0){:target="_blank"}.
 
 WebApiShard comes with a [WebApiSettings] class that holds settings to configure the service.
 
@@ -16,7 +16,7 @@ To add the shard to the forge, the `IForgeBuilder` extension `UseApi` has to be 
 public static IForgeBuilder UseApi(this IForgeBuilder forgeBuilder, Action<WebApiOptions>? options = null)
 ```
 
-WebApiShard implements the Web API controllers using the standard aspnet [ControllerBase](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.controllerbase?view=aspnetcore-5.0){:target="_blank"} class but decorates it with a set of default attributes needed to expose these controllers in the right context.
+WebApiShard implements the Web API controllers using the standard aspnet [ControllerBase](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.controllerbase?view=aspnetcore-8.0){:target="_blank"} class but decorates it with a set of default attributes needed to expose these controllers in the right context.
 To create a proper WebApiShard controller, an abstract base class `MithrilControllerBase` exists that applies already the required attributes.
 
 ```c#
@@ -55,7 +55,7 @@ public abstract class WebApiArea
 !!! note
 	WebApiShard controllers have to belong to a specific area. More information in [Creating a Controller] section.
 
-`DisableByEndPointActionFilterAttribute` class, that's a registered [ActionFilterAttribute](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.filters.actionfilterattribute?view=aspnetcore-5.0){:target="_blank"}, is responsible to enforce proper checks against executing an action on an unspecified, unknown or disabled area.
+`DisableByEndPointActionFilterAttribute` class, that's a registered [ActionFilterAttribute](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.filters.actionfilterattribute?view=aspnetcore-8.0){:target="_blank"}, is responsible to enforce proper checks against executing an action on an unspecified, unknown or disabled area.
 
 !!! warning
 	The current implementation may be subject to changes to implement the authentication and authorization layer.

--- a/docs/shards/web-api/using-webapishard.md
+++ b/docs/shards/web-api/using-webapishard.md
@@ -19,7 +19,7 @@ public static IForgeBuilder UseApi(this IForgeBuilder forgeBuilder, Action<WebAp
 
 WebApiOptions class allows to customize the discovery process that's responsible to find and register Web API controllers end include them into a specific [ApiServiceDefinition](#apiservicedefinition).
 
-The discovery process happens during WebApiShard initialization: it generates an [ApplicationPart](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.applicationparts.applicationpart?view=aspnetcore-5.0){:target="blank"} for each registered shard that will include all discovered `MithrilControllerBase`(ControllerBase) types defined in the shard assembly.
+The discovery process happens during WebApiShard initialization: it generates an [ApplicationPart](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.applicationparts.applicationpart?view=aspnetcore-8.0){:target="blank"} for each registered shard that will include all discovered `MithrilControllerBase`(ControllerBase) types defined in the shard assembly.
 
 ### ControllersSeeker
 

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ description: Mithril Shards home page
 
 ## Goal
 
-Mithril Shards goal is to implement a .NET 6 extensible P2P network & distributed services library from scratch with focus on architecture and performance.
+Mithril Shards goal is to implement a .NET 8 extensible P2P network & distributed services library from scratch with focus on architecture and performance.
 
 Allows you to define custom network serialization protocol, easily handle payload messages and interact with the software leveraging any available features (named Shards) like Web API endpoints, cross platform Blazor UI,  and a lot of other exciting stuffs that community can implements and release to the public too!
 
@@ -22,7 +22,7 @@ As a proof of concept, a new Bitcoin full node is being developed using this lib
 
 A random list of available tech used within Mithril Shards.
 
-- [.Net 6](https://dotnet.microsoft.com/download/dotnet/5.0) - ... for everything.
+- [.Net 8](https://dotnet.microsoft.com/download/dotnet/8.0) - ... for everything.
 - [Bedrock Framework](https://github.com/davidfowl/BedrockFramework/) - TCP/IP default connectivity implementation.
 - [Swashbuckle](https://github.com/domaindrivendev/Swashbuckle.AspNetCore) - to handle Web API in a configurable, multi-area environment and have a playground to test APIs with swagger.
 - [Serilog](https://github.com/serilog/serilog-aspnetcore) - default logging implementation.

--- a/src/MithrilShards.Network.Bedrock/MithrilForgeClientConnectionHandler.cs
+++ b/src/MithrilShards.Network.Bedrock/MithrilForgeClientConnectionHandler.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.Connections;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using MithrilShards.Core.EventBus;
-using MithrilShards.Core.Extensions;
 using MithrilShards.Core.Network;
 using MithrilShards.Core.Network.Client;
 using MithrilShards.Core.Network.Events;
@@ -34,7 +33,7 @@ public class MithrilForgeClientConnectionHandler(
       using var _ = logger.BeginScope("Peer {PeerId} connected to outbound {PeerEndpoint}", connection.ConnectionId, connection.LocalEndPoint);
 
       ProtocolReader reader = connection.CreateReader();
-      INetworkProtocolMessageSerializer protocol = serviceProvider.GetRequiredService<INetworkProtocolMessageSerializer>();
+      INetworkProtocolMessageSerializer protocol = serviceProviderScope.ServiceProvider.GetRequiredService<INetworkProtocolMessageSerializer>();
 
       IPeerContext peerContext = peerContextFactory.CreateOutgoingPeerContext(connection.ConnectionId,
                                                                                          connection.LocalEndPoint!,


### PR DESCRIPTION
fix a nasty bug of the connection handler that wasn't using scoped serviceProvider to resolve the INetworkProtocolMessageSerializer service